### PR TITLE
Add CORS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,23 @@ class OrderExportComposer implements CsvComposer
 
 }
 ```
+### CORS Headers
+When using Csvme in api endpoints, you can add the `Access-Control-Allow-Origin` header using the `setCorsHeader()` method. 
+The method defaults to allow all origins but a specific origin can be passed in as an argument in the following way.
+
+```php
+$csv = new Csvme();
+
+$csv->withHeader(['ID', 'Total', 'Number of Items', 'Created At'])
+    ->withLayout(function(Order $order) {
+        return [
+            $order->id,
+            $order->total,
+            $order->items->count(),
+            $order->created_at->format('d-m-Y'),
+        ];
+    })
+    ->withItems($orders)
+    ->setCorsHeader('https://test.com')
+    ->output();
+``` 

--- a/src/CSVMe.php
+++ b/src/CSVMe.php
@@ -68,15 +68,10 @@ class Csvme
      *
      * @param CsvComposer|null $composer
      */
-    public function output(CsvComposer $composer = null, bool $addCorsHeader = null)
+    public function output(CsvComposer $composer = null)
     {
         if ($composer) {
             $composer->compose($this);
-        }
-
-        // Cors header is required when requesting export from a different server
-        if($addCorsHeader) {
-            header('Access-Control-Allow-Origin: *');
         }
 
         // Process the provided headers and items before outputting
@@ -166,5 +161,16 @@ class Csvme
         foreach ($this->items as $item) {
             $this->getCsv()->insertOne($layoutClosure($item));
         }
+    }
+
+    /**
+     * @return $this
+     * Sets the cors header to allow csv to be downloaded from a separate server
+     */
+    public function setCorsHeader()
+    {
+        header('Access-Control-Allow-Origin: *');
+
+        return $this;
     }
 }

--- a/src/CSVMe.php
+++ b/src/CSVMe.php
@@ -68,10 +68,15 @@ class Csvme
      *
      * @param CsvComposer|null $composer
      */
-    public function output(CsvComposer $composer = null)
+    public function output(CsvComposer $composer = null, bool $addCorsHeader = null)
     {
         if ($composer) {
             $composer->compose($this);
+        }
+
+        // Cors header is required when requesting export from a different server
+        if($addCorsHeader) {
+            header('Access-Control-Allow-Origin: *');
         }
 
         // Process the provided headers and items before outputting

--- a/src/CSVMe.php
+++ b/src/CSVMe.php
@@ -167,9 +167,9 @@ class Csvme
      * @return $this
      * Sets the cors header to allow csv to be downloaded from a separate server
      */
-    public function setCorsHeader()
+    public function setCorsHeader($origins = '*')
     {
-        header('Access-Control-Allow-Origin: *');
+        header("Access-Control-Allow-Origin: {$origins}");
 
         return $this;
     }


### PR DESCRIPTION
This pr adds the ability to optionally set cors headers on csv export requests. When using the package in an api endpoint that's being called by a separate server, the export fails due to the absence of these headers. 